### PR TITLE
[GTSAM catkin] Use build directory for building the package

### DIFF
--- a/gtsam_catkin/CMakeLists.txt
+++ b/gtsam_catkin/CMakeLists.txt
@@ -99,9 +99,9 @@ else ()
             GIT_TAG "4.2a9"
             GIT_PROGRESS "true"
             CMAKE_CACHE_ARGS "-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true"
-            PREFIX "${CMAKE_SOURCE_DIR}"
-            SOURCE_DIR "${CMAKE_SOURCE_DIR}/gtsam"
-            BINARY_DIR "${CMAKE_SOURCE_DIR}/tmp"
+            PREFIX "${CMAKE_BINARY_DIR}/gtsam_external"
+            SOURCE_DIR "${CMAKE_BINARY_DIR}/gtsam_external/src/gtsam"
+            BINARY_DIR "${CMAKE_BINARY_DIR}/gtsam_external/build"
             CMAKE_ARGS
             -DCMAKE_BUILD_TYPE=Release
             -DGTSAM_POSE3_EXPMAP=ON


### PR DESCRIPTION
Currently, building GTSAM catkin downloads into the source directory a bunch of repos which later cause issues when re-building the package.

To ensure that a catkin clean removes any residual, I have moved the files that are being downloaded into the build folder for this package.

Tested on local machine