### PR TITLE
Improved build/install automation and minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-gtsam_catkin/gtsam
 gtsam_catkin/src
-gtsam_catkin/tmp

--- a/gtsam_catkin/CMakeLists.txt
+++ b/gtsam_catkin/CMakeLists.txt
@@ -37,12 +37,9 @@ macro(get_run_deps)
             list(APPEND ${PROJECT_NAME}_CATKIN_RUN_DEPENDS ${dep})
         endif ()
     endforeach ()
-
 endmacro()
 
-get_run_deps(INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include
-        LIBRARIES tbb
-        )
+get_run_deps(INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include LIBRARIES tbb)
 
 # 1 - Check whether variable is set -----------------------------------------------------------
 if (DEFINED ENV{GTSAM_DIR})
@@ -54,43 +51,40 @@ if (DEFINED ENV{GTSAM_DIR})
     message("GTSAM libs: ${GTSAM_LIBRARY_DIR}")
 
     catkin_package(
-            CATKIN_DEPENDS ${CATKIN_PACKAGE_DEPENDENCIES}
-            DEPENDS GTSAM
-            INCLUDE_DIRS ${GTSAM_INCLUDE_DIR}
-            LIBRARIES
-            gtsam gtsam_unstable
+        INCLUDE_DIRS
+            ${GTSAM_INCLUDE_DIR}
+        LIBRARIES
+            gtsam
+            gtsam_unstable
+            metis-gtsam
             ${CS_PROJECT_LIBRARIES}
+        CATKIN_DEPENDS
+            ${CATKIN_PACKAGE_DEPENDENCIES}
+            ${${PROJECT_NAME}_CATKIN_RUN_DEPENDS}
+        DEPENDS GTSAM
     )
-
-    # 2 - Check whether GTSAM is installed -------------------------------------------------------
+# 2 - Check whether GTSAM is installed -------------------------------------------------------
 elseif (GTSAM_FOUND)
     message("${BoldMagenta}INFO: Found GTSAM installation.${ColourReset}")
 
-    message("GTSAM include path: ${GTSAM_INCLUDE_DIR}")
-    message("GTSAM libs: ${GTSAM_LIBRARY_DIR}")
+    find_package(GTSAM_UNSTABLE REQUIRED)
 
     catkin_package(
-            CATKIN_DEPENDS ${CATKIN_PACKAGE_DEPENDENCIES}
-            DEPENDS GTSAM
-            INCLUDE_DIRS ${GTSAM_INCLUDE_DIR}
-            LIBRARIES
-            gtsam gtsam_unstable
+        INCLUDE_DIRS
+            ${GTSAM_INCLUDE_DIR}
+        LIBRARIES
+            gtsam
+            gtsam_unstable
+            metis-gtsam
             ${CS_PROJECT_LIBRARIES}
+        CATKIN_DEPENDS
+            ${CATKIN_PACKAGE_DEPENDENCIES}
+            ${${PROJECT_NAME}_CATKIN_RUN_DEPENDS}
+        DEPENDS GTSAM
     )
-
-    # Path differs whether installed from PPA or (locally) from source
-#    if (EXISTS "${GTSAM_DIR}/../../../../include/")
-#        set(GTSAM_INCLUDE_DIR_MAN "${GTSAM_DIR}/../../../../include/")
-#    else ()
-#        set(GTSAM_INCLUDE_DIR_MAN "${GTSAM_DIR}/../../../include/")
-#    endif ()
-
-    # 3 - Compile in catkin workspace -------------------------------------------------------------
+# 3 - Compile in catkin workspace -------------------------------------------------------------
 else ()
     message("${BoldMagenta}INFO: Neither variable GTSAM_DIR is set, nor could GTSAM be found, hence compiling in workspace.${ColourReset}")
-
-    # Newer version of CMake is required
-    # cmake_minimum_required(VERSION 3.18)
 
     # Catkinization of GTSAM
     include(ExternalProject)
@@ -132,14 +126,14 @@ else ()
 
     # Final catkin package --------------------------------------------------
     catkin_package(
-            INCLUDE_DIRS
+        INCLUDE_DIRS
             ${CATKIN_DEVEL_PREFIX}/include
-            LIBRARIES
+        LIBRARIES
             ${CATKIN_DEVEL_PREFIX}/lib/libgtsam.so
             ${CATKIN_DEVEL_PREFIX}/lib/libgtsam_unstable.so
             ${CATKIN_DEVEL_PREFIX}/lib/libmetis-gtsam.so
             ${CS_PROJECT_LIBRARIES}
-            CATKIN_DEPENDS
+        CATKIN_DEPENDS
             ${${PROJECT_NAME}_CATKIN_RUN_DEPENDS}
             ${CATKIN_PACKAGE_DEPENDENCIES}
     )

--- a/gtsam_catkin/CMakeLists.txt
+++ b/gtsam_catkin/CMakeLists.txt
@@ -95,14 +95,15 @@ else ()
     file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 
     ExternalProject_Add(GTSAM
-            GIT_REPOSITORY "https://github.com/borglab/gtsam.git"
-            GIT_TAG "4.2a9"
-            GIT_PROGRESS "true"
-            CMAKE_CACHE_ARGS "-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true"
-            PREFIX "${CMAKE_BINARY_DIR}/gtsam_external"
-            SOURCE_DIR "${CMAKE_BINARY_DIR}/gtsam_external/src/gtsam"
-            BINARY_DIR "${CMAKE_BINARY_DIR}/gtsam_external/build"
-            CMAKE_ARGS
+        GIT_REPOSITORY "https://github.com/borglab/gtsam.git"
+        GIT_TAG "4.2a9"
+        GIT_PROGRESS "true"
+        PREFIX      "${CMAKE_SOURCE_DIR}"
+        TMP_DIR     "${CMAKE_BINARY_DIR}/gtsam/tmp"
+        BINARY_DIR  "${CMAKE_BINARY_DIR}/gtsam/build"
+        INSTALL_DIR "${CATKIN_DEVEL_PREFIX}"
+        CMAKE_CACHE_ARGS "-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true"
+        CMAKE_ARGS
             -DCMAKE_BUILD_TYPE=Release
             -DGTSAM_POSE3_EXPMAP=ON
             -DGTSAM_ROT3_EXPMAP=ON
@@ -110,8 +111,7 @@ else ()
             -DGTSAM_USE_SYSTEM_EIGEN=ON
             -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF
             -DCMAKE_INSTALL_PREFIX=${CATKIN_DEVEL_PREFIX}
-            INSTALL_COMMAND make install
-            )
+    )
 
     # Dependencies ---------------------------------------------------------
     add_dependencies(GTSAM ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})

--- a/gtsam_catkin/CMakeLists.txt
+++ b/gtsam_catkin/CMakeLists.txt
@@ -43,7 +43,7 @@ get_run_deps(INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include LIBRARIES tbb)
 
 # 1 - Check whether variable is set -----------------------------------------------------------
 if (DEFINED ENV{GTSAM_DIR})
-    message("${BoldMagenta}INFO: Found manually set path to GTSAM. Using version located at $ENV{GTSAM_DIR}.${ColourReset}")
+    message("${BoldMagenta}INFO: Found GTSAM via environment variable at $ENV{GTSAM_DIR}.${ColourReset}")
 
     set(GTSAM_DIR ENV{GTSAM_DIR})
     find_package(GTSAM ${GTSAM_MIN_VERSION} CONFIG REQUIRED)
@@ -65,7 +65,7 @@ if (DEFINED ENV{GTSAM_DIR})
     )
 # 2 - Check whether GTSAM is installed -------------------------------------------------------
 elseif (GTSAM_FOUND)
-    message("${BoldMagenta}INFO: Found GTSAM installation.${ColourReset}")
+    message("${BoldMagenta}INFO: Found GTSAM installation at ${GTSAM_DIR}.${ColourReset}")
 
     find_package(GTSAM_UNSTABLE REQUIRED)
 

--- a/gtsam_catkin/CMakeLists.txt
+++ b/gtsam_catkin/CMakeLists.txt
@@ -11,7 +11,9 @@ find_package(catkin REQUIRED COMPONENTS
         )
 
 # Check whether gtsam can be found
-find_package(GTSAM QUIET)
+set(GTSAM_MIN_VERSION 4.2.0)
+set(GTSAM_TAG ${GTSAM_MIN_VERSION})
+find_package(GTSAM ${GTSAM_MIN_VERSION} QUIET)
 find_package(Eigen3 REQUIRED)
 
 # Color
@@ -47,7 +49,7 @@ if (DEFINED ENV{GTSAM_DIR})
     message("${BoldMagenta}INFO: Found manually set path to GTSAM. Using version located at $ENV{GTSAM_DIR}.${ColourReset}")
 
     set(GTSAM_DIR ENV{GTSAM_DIR})
-    find_package(GTSAM CONFIG REQUIRED)
+    find_package(GTSAM ${GTSAM_MIN_VERSION} CONFIG REQUIRED)
     message("GTSAM include path: ${GTSAM_INCLUDE_DIR}")
     message("GTSAM libs: ${GTSAM_LIBRARY_DIR}")
 
@@ -96,7 +98,7 @@ else ()
 
     ExternalProject_Add(GTSAM
         GIT_REPOSITORY "https://github.com/borglab/gtsam.git"
-        GIT_TAG "4.2a9"
+        GIT_TAG "${GTSAM_TAG}"
         GIT_PROGRESS "true"
         PREFIX      "${CMAKE_SOURCE_DIR}"
         TMP_DIR     "${CMAKE_BINARY_DIR}/gtsam/tmp"

--- a/gtsam_catkin/CMakeLists.txt
+++ b/gtsam_catkin/CMakeLists.txt
@@ -47,8 +47,7 @@ if (DEFINED ENV{GTSAM_DIR})
 
     set(GTSAM_DIR ENV{GTSAM_DIR})
     find_package(GTSAM ${GTSAM_MIN_VERSION} CONFIG REQUIRED)
-    message("GTSAM include path: ${GTSAM_INCLUDE_DIR}")
-    message("GTSAM libs: ${GTSAM_LIBRARY_DIR}")
+    find_package(GTSAM_UNSTABLE REQUIRED)
 
     catkin_package(
         INCLUDE_DIRS


### PR DESCRIPTION
- bumped GTSAM 4.2a9 (a 4.2.0 prerelease) to 4.2.0
- added finding of GTSAM_UNSTABLE for preinstalled GTSAM option, as this was causing downstream linker errors
- changed the src directory of the downloaded gtsam files to be within the src tree, while the tmp and build files are in the normal build directory
- removed INSTALL_COMMAND as this is not necessary, and by using `make install` instead of `cmake --build . --target install` prevents the jobserver from propagating